### PR TITLE
Updated :all as list

### DIFF
--- a/lib/authorize.ex
+++ b/lib/authorize.ex
@@ -35,7 +35,7 @@ defmodule Authorize do
         |> Enum.reverse
         |> Enum.filter(fn
           {acts, _, _} when is_atom(acts) -> acts == :all || acts == actions
-          {acts, _, _} -> acts == :all || Enum.member?(acts, actions)
+          {acts, _, _} -> acts == [:all] || Enum.member?(acts, actions)
         end)
         |> Enum.reduce(:undecided, fn
           ({_actions, description, rule_func}, :undecided) ->


### PR DESCRIPTION
The guard clause above:
`when is_atom(acts)` is invoked in line 37, this means that :all will never be encountered. Therefore, updated to have `[:all]`